### PR TITLE
Updating to remove IMG size and Receptive field

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ import torch.utils.data
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 
+from audiomentations import Compose, AddGaussianNoise, Shift, Gain
+
 import argparse
 import re
 import numpy as np
@@ -131,12 +133,36 @@ class MelSpectogram(torch.nn.Module):
 
         return mel
 
+class WavToSpec(torch.nn.Module):
+    def __init__(
+        self,
+        input_freq=16000,
+        resample_freq=16000,
+        n_fft=1024,
+        n_mel=32,
+        stretch_factor=0.8,
+    ):
+        super().__init__()
+
+        self.spec = torchaudio.transforms.Spectrogram(n_fft=n_fft, power=2)
+
+        self.mel_scale = torchaudio.transforms.MelScale(
+            n_mels=n_mel, sample_rate=resample_freq, n_stft=n_fft // 2 + 1)
+
+    def forward(self, waveform: torch.Tensor) -> torch.Tensor:
+        spec = self.spec(waveform)
+        # spec = torch.from_numpy(librosa.power_to_db(spec))
+        # mel = self.mel_scale(spec)
+        spec = torch.from_numpy(librosa.power_to_db(spec))
+
+        return spec
+
 labels = np.load('./lables.npy')
 labels = labels.tolist()
 # transform = torchaudio.transforms.MelSpectrogram(new_sample_rate,n_fft = 1024, hop_length=512,n_mels =32)
 
-pipeline_to_mel = MelSpectogram()
-pipeline_to_mel.to(dtype=torch.float32)
+pipeline_to_spec = WavToSpec()
+pipeline_to_spec.to(dtype=torch.float32)
 
 def label_to_index(word):
     # Return the position of the word in labels
@@ -154,6 +180,13 @@ def pad_sequence(batch):
     batch = torch.nn.utils.rnn.pad_sequence(batch, batch_first=True, padding_value=0.)
     return batch.permute(0, 2, 1)
 
+def pad_sequence_aug(batch):
+    # Make all tensor in a batch the same length by padding with zeros
+    batch = [item.t() for item in batch]
+    batch = torch.nn.utils.rnn.pad_sequence(batch, batch_first=True, padding_value=0.)
+    batch = agument(samples=batch, sample_rate=16000)
+    batch = torch.Tensor(batch)
+    return batch.permute(0, 2, 1)
 
 def collate_fn(batch):
 
@@ -167,11 +200,11 @@ def collate_fn(batch):
         tensors += [waveform]
         targets += [label_to_index(label)]
         # targets += torch.eye(35)[label_to_index(label)]
-
+    # tensors = np.array(tensors)
     # Group the list of tensors into a batched tensor
     tensors = pad_sequence(tensors)
-    tensors = pipeline_to_mel(tensors)
-    tensors = librosa.power_to_db(tensors)
+    tensors = pipeline_to_spec(tensors)
+    # tensors = librosa.power_to_db(tensors)
     tensors = torch.tensor(tensors)
     # tensors = 10*math.log10(tensors)
     # tensors = 10*torch.log10(tensors)
@@ -180,20 +213,54 @@ def collate_fn(batch):
     return tensors, targets
 
 
+agument = Compose([
+    Gain(p=0.25),
+    AddGaussianNoise(
+        min_amplitude=1,
+        max_amplitude=2,
+        p=0.25
+    ),
+    Shift(p=0.25),
+])
+
+def aug_collate_fn(batch):
+
+    # A data tuple has the form:
+    # waveform, sample_rate, label, speaker_id, utterance_number
+
+    tensors, targets = [], []
+
+    # Gather in lists, and encode labels as indices
+    for waveform, _, label, *_ in batch:
+        tensors += [waveform]
+        targets += [label_to_index(label)]
+        # targets += torch.eye(35)[label_to_index(label)]
+    # tensors = np.array(tensors)
+    # Group the list of tensors into a batched tensor
+    tensors = pad_sequence_aug(tensors)
+    tensors = pipeline_to_spec(tensors)
+    # tensors = librosa.power_to_db(tensors)
+    tensors = torch.tensor(tensors)
+    # tensors = 10*math.log10(tensors)
+    # tensors = 10*torch.log10(tensors)
+    targets = torch.stack(targets)
+
+    return tensors, targets
+
 
 train_loader = torch.utils.data.DataLoader(
     train_set,
     batch_size=train_batch_size,
     shuffle=True,
-    num_workers=2,
+    num_workers=4,
     pin_memory=False,
-    collate_fn = collate_fn
+    collate_fn = aug_collate_fn
 )
 train_push_loader = torch.utils.data.DataLoader(
     train_set,
     batch_size=train_push_batch_size,
     shuffle=False,
-    num_workers=2,
+    num_workers=4,
     pin_memory=False,
     collate_fn = collate_fn
 )
@@ -202,7 +269,7 @@ test_loader = torch.utils.data.DataLoader(
     batch_size=test_batch_size,
     shuffle=False,
     drop_last=False,
-    num_workers=2,
+    num_workers=4,
     pin_memory=False,
     collate_fn = collate_fn
 )
@@ -274,7 +341,7 @@ for epoch in range(num_train_epochs):
     accu = tnt.test(model=ppnet_multi, dataloader=test_loader,
                     class_specific=class_specific, log=log)
     save.save_model_w_condition(model=ppnet, model_dir=model_dir, model_name=str(epoch) + 'nopush', accu=accu,
-                                target_accu=0.80, log=log)
+                                target_accu=0.86, log=log)
 
     if epoch >= push_start and epoch in push_epochs:
         push.push_prototypes(
@@ -293,18 +360,18 @@ for epoch in range(num_train_epochs):
         accu = tnt.test(model=ppnet_multi, dataloader=test_loader,
                         class_specific=class_specific, log=log)
         save.save_model_w_condition(model=ppnet, model_dir=model_dir, model_name=str(epoch) + 'push', accu=accu,
-                                    target_accu=0.80, log=log)
+                                    target_accu=0.86, log=log)
 
         if prototype_activation_function != 'linear':
             tnt.last_only(model=ppnet_multi, log=log)
-            for i in range(10):
+            for i in range(20):
                 log('iteration: \t{0}'.format(i))
                 _ = tnt.train(model=ppnet_multi, dataloader=train_loader, optimizer=last_layer_optimizer,
                               class_specific=class_specific, coefs=coefs, log=log)
                 accu = tnt.test(model=ppnet_multi, dataloader=test_loader,
                                 class_specific=class_specific, log=log)
                 save.save_model_w_condition(model=ppnet, model_dir=model_dir, model_name=str(epoch) + '_' + str(i) + 'push', accu=accu,
-                                            target_accu=0.80, log=log)
+                                            target_accu=0.99, log=log)
    
 logclose()
 

--- a/model.py
+++ b/model.py
@@ -30,8 +30,7 @@ base_architecture_to_features = {'resnet18': resnet18_features,
 
 class PPNet(nn.Module):
 
-    def __init__(self, features, img_size, prototype_shape,
-                 proto_layer_rf_info, num_classes, init_weights=True,
+    def __init__(self, features, img_size, prototype_shape, num_classes, init_weights=True,
                  prototype_activation_function='log',
                  add_on_layers_type='bottleneck'):
 
@@ -59,8 +58,6 @@ class PPNet(nn.Module):
         num_prototypes_per_class = self.num_prototypes // self.num_classes
         for j in range(self.num_prototypes):
             self.prototype_class_identity[j, j // num_prototypes_per_class] = 1
-
-        self.proto_layer_rf_info = proto_layer_rf_info
 
         # this has to be named features to allow the precise loading
         self.features = features
@@ -240,18 +237,14 @@ class PPNet(nn.Module):
         rep = (
             'PPNet(\n'
             '\tfeatures: {},\n'
-            '\timg_size: {},\n'
             '\tprototype_shape: {},\n'
-            '\tproto_layer_rf_info: {},\n'
             '\tnum_classes: {},\n'
             '\tepsilon: {}\n'
             ')'
         )
 
         return rep.format(self.features,
-                          self.img_size,
                           self.prototype_shape,
-                          self.proto_layer_rf_info,
                           self.num_classes,
                           self.epsilon)
 
@@ -291,15 +284,10 @@ def construct_PPNet(base_architecture, pretrained=True, img_size=224,
                     add_on_layers_type='bottleneck'):
     features = base_architecture_to_features[base_architecture](pretrained=pretrained)
     layer_filter_sizes, layer_strides, layer_paddings = features.conv_info()
-    proto_layer_rf_info = compute_proto_layer_rf_info_v2(img_size=img_size,
-                                                         layer_filter_sizes=layer_filter_sizes,
-                                                         layer_strides=layer_strides,
-                                                         layer_paddings=layer_paddings,
-                                                         prototype_kernel_size=prototype_shape[2])
+
     return PPNet(features=features,
                  img_size=img_size,
                  prototype_shape=prototype_shape,
-                 proto_layer_rf_info=proto_layer_rf_info,
                  num_classes=num_classes,
                  init_weights=True,
                  prototype_activation_function=prototype_activation_function,

--- a/settings.py
+++ b/settings.py
@@ -11,9 +11,9 @@ data_path = './datasets/'
 train_dir = data_path + 'train_cropped_augmented/'
 test_dir = data_path + 'test_cropped/'
 train_push_dir = data_path + 'train_cropped/'
-train_batch_size = 85
-test_batch_size = 85
-train_push_batch_size = 85
+train_batch_size = 256
+test_batch_size = 256
+train_push_batch_size = 256
 
 joint_optimizer_lrs = {'features': 1e-4,
                        'add_on_layers': 3e-3,
@@ -32,7 +32,7 @@ coefs = {
     'l1': 1e-4,
 }
 
-num_train_epochs = 45
+num_train_epochs = 100
 num_warm_epochs = 0
 
 push_start = 5


### PR DESCRIPTION
Now taking in any size image to test on spectograms meaning less loss Removing the requirement for receptive field such that any image size can be supported. Also appeared redundant.